### PR TITLE
Add Discord server permanent invite to the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,10 @@
 				</div>
 				<div class="footer-col col-md-4">
 					<h3>Chat with us!</h3>
-					<p>Chat with us on <a href="irc://irc.esper.net:6667">#NovaAPI</a> at irc.esper.net.</p>
+					<p>
+						Chat with us on <a href="irc://irc.esper.net:6667">#NovaAPI</a> at irc.esper.net.<br>
+						Or at <a href="https://discord.gg/Sh63S4H">Neatly Organized Voxel API</a> with <a href="https://discordapp.com/">Discord</a>.
+					</p>
 				</div>
 				<div class="footer-col col-md-4">
 					<h3>Sponsor</h3>


### PR DESCRIPTION
This PR adds a permanent invite for the official NOVA Discord server to the footer.