### PR TITLE
Make the site HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,16 @@
 /*
 
 # Except:
-!LICENSE.txt
+!LICENSE
 
 # Sources
 !/_includes
 !/_layouts
 !/_sass
 !/static
+!index.html
+!_config.yml
+!CNAME
 
 # github
 !/.gitignore

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: NOVA
 description: NOVA (Neatly Organized Voxel API) is a modding framework for voxel games.
 author: shadowfacts
 baseurl: ""
-url: "http://novaapi.net"
+url: "https://novaapi.net"
 
 # Build Settings
 markdown: redcarpet

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,10 +20,6 @@
 						Or at <a href="https://discord.gg/Sh63S4H">Neatly Organized Voxel API</a> with <a href="https://discordapp.com/">Discord</a>.
 					</p>
 				</div>
-				<div class="footer-col col-md-4">
-					<h3>Sponsor</h3>
-					<p><a href="http://www.thoughtstem.com/" target="_blank"><img src="http://www.thoughtstem.com/assets/logo.png"/></a></p>
-				</div>
 			</div>
 		</div>
 	</div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -30,13 +30,13 @@
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown">More <b class="caret"></b></a>
 					<ul class="dropdown-menu">
 						<li>
-                            <a href="http://artifactory.novaapi.net/">Artifactory</a>
+                            <a href="https://artifactory.novaapi.net/">Artifactory</a>
                         </li>
 						<li>
-                            <a href="http://ci.novaapi.net/">Jenkins</a>
+                            <a href="https://ci.novaapi.net/">Jenkins</a>
                         </li>
                         <li>
-                            <a href="http://ci.novaapi.net/job/NOVA-Core/javadoc/">Javadoc</a>
+                            <a href="https://ci.novaapi.net/job/NOVA-Core/javadoc/">Javadoc</a>
                         </li>
                         <li>
                             <a href="https://waffle.io/NOVA-Team/NOVA-Core">Waffle</a>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ layout: default
 				<p>NOVA makes it easier than ever to test mods with the ability to create unit tests, something unheard of with other modding frameworks.</p>
 			</div>
 			<div>
-				<p>NOVA is open. We use <a href="http://choosealicense.com/licenses/lgpl-3.0/">LGPLv3</a> to be sure that the API can be used by anyone without any legal issues. We also encourage everyone to contribute to the project.</p>
+				<p>NOVA is open. We use <a href="https://choosealicense.com/licenses/lgpl-3.0/">LGPLv3</a> to be sure that the API can be used by anyone without any legal issues. We also encourage everyone to contribute to the project.</p>
 			</div>
 			<div>
 				<p>NOVA is abstract so it's mods may work for multiple games. Thanks to modular design of the API we can port it to almost any voxel game.</p>


### PR DESCRIPTION
This PR should make the site HTTPS.
Note that [Minecraft Forge](http://minecraftforge.net) and [ThoughtSTEM](http://thoughtstem.com) don’t support HTTPS, and as such the ThoughtSTEM logo is not HTTPS.